### PR TITLE
(bug): fix the unrecognized --no-pager argument

### DIFF
--- a/website/docs/git-wiki.md
+++ b/website/docs/git-wiki.md
@@ -84,7 +84,7 @@ git log -1 {FILE_PATH}
 ### How to show the commit logs without paging?
 
 ```bash
-git log --no-pager
+git --no-pager log
 ```
 
 ### How to show commit logs in a custom format?


### PR DESCRIPTION
```
> git log --no-pager
fatal: unrecognized argument: --no-pager
```

`--no-pager is used as an argument for the `git` command itself to disable the pager.

