### PR TITLE
algolia: refactor the crawler

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,16 +1,16 @@
 name: Algolia Crawler
 
 on:
-  push:
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
+      - name: Sleep for 15s
+        run: sleep 15
       - name: Algolia Crawler Automatic Crawl
-        uses: algolia/algoliasearch-crawler-github-actions@v1.1.0
+        uses: algolia/algoliasearch-crawler-github-actions@v1.10.0
         with:
           crawler-user-id: ${{ secrets.ALGOLIA_CRAWLER_USER_ID }}
           crawler-api-key: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "crawl": "./trigger_algolia_crawler.sh"
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.1",

--- a/website/trigger_algolia_crawler.sh
+++ b/website/trigger_algolia_crawler.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+echo "Triggering Algolia crawler..."
+
+test -z "$GITHUB_WORKFLOW_DISPATCH" && echo "Preview mode, exiting..." && exit 0
+
+curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${GITHUB_WORKFLOW_DISPATCH}" \
+  -d '{"ref":"main"}'


### PR DESCRIPTION
- Fix the issue that Algolia crawler fails to crawl the latest documents because the workflow is triggered before the website deployment completed.
- Build command: `yarn build && yarn crawl`